### PR TITLE
Dev/1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@
 
 - **Feature**: Added pretty print for gdb in debug (launch) configuration
 
-## Version 1.2.0: August 25, 2021
-
-- Added pretty print for gdb in debug (launch) configuration
-
 ## Version 1.1.5: August 16, 2021
 
 - **Bugfix**: Fixed problem with empty arguments for executing the binary on windows with mingw compiler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 1.3.0: August 28, 2021
 
-- **Improvement**: Update gcc/clang search logic, to only search in /usr/ and /usr/bin/ on linux, and only in paths containing cygwin, mingw or msys on windows
+- **Improvement**: Update gcc/clang search logic, to only search in */usr/* and */usr/bin/* on linux, and only in paths containing cygwin, mingw or msys on windows
 - **Improvement**: If the build path contains whitespaces or non-extended ascii chars the extension's experimental code runner is used instead of Makefile
 
 ## Version 1.2.0: August 25, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,46 +1,51 @@
 # C/C++ Runner Change Log
 
-## Version 1.2.0: Planned
+## Version 1.3.0: August 28, 2021
 
-- Extend the experimental setting
+- **Improvement**: Update gcc/clang search logic, to only search in /usr/ and /usr/bin/ on linux, and only in paths containing cygwin, mingw or msys on windows
+- **Improvement**: If the build path contains whitespaces the extension's experimental code runner is used instead of Makefile
+
+## Version 1.2.0: August 25, 2021
+
+- **Feature**: Added pretty print for gdb in debug (launch) configuration
 
 ## Version 1.1.5: August 16, 2021
 
-- Fixed problem with empty arguments for executing the binary on windows with mingw compiler
+- **Bugfix**: Fixed problem with empty arguments for executing the binary on windows with mingw compiler
 
 ## Version 1.1.4: August 15, 2021
 
-- Fixed problem with Linker Args
-- Updated README
+- **Bugfix**: Fixed problem with Linker Args
+- **Info**: Updated README
 
 ## Version 1.1.3: July 27, 2021
 
-- Fixed problem with Makefile in .vscode folder (regarding my Udemy Courses setup)
+- **Bugfix**: Fixed problem with Makefile in .vscode folder (regarding my Udemy Courses setup)
 
 ## Version 1.1.2: July 26, 2021
 
-- Updated run task for windows such that the executable name has .exe file extension since this is needed for MinGW
-- Fixed bug that debugging the release build was not possible
+- **Bugfix**: Updated run task for windows such that the executable name has .exe file extension since this is needed for MinGW
+- **Bugfix**: Fixed bug that debugging the release build was not possible
 
 ## Version 1.1.1: July 26, 2021
 
-- Creating and deleting build folder is now executed by the extension code and not anymore by the Makefile
+- **Improvement**: Creating and deleting build folder is now executed by the extension code and not anymore by the Makefile
 
 ## Version 1.1.0: July 24, 2021
 
-- Added experimental setting to run compiler commands without Makefile
+- **Feature**: Added experimental setting to run compiler commands without Makefile
 
 ## Version 1.0.2: July 9, 2021
 
-- Fixed bug for compiler search on Linux and Mac
+- **Bugfix**: Fixed bug for compiler search on Linux and Mac
 
 ## Version 1.0.1: July 4, 2021
 
-- Added information message if a path has whitespaces. Makefile can not work with paths/filenames with whitespaces properly.
+- **Info**: Added information message if a path has whitespaces. Makefile can not work with paths/filenames with whitespaces properly.
 
 ## Version 1.0.0: July 3, 2021
 
-- Following settings are now array of strings instead of strings:
+- **Improvement**: Following settings are now array of strings instead of strings:
   - `C_Cpp_runner.warnings`
   - `C_Cpp_runner.includePaths`
   - `C_Cpp_runner.compilerArgs`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 1.3.0: August 28, 2021
 
 - **Improvement**: Update gcc/clang search logic, to only search in /usr/ and /usr/bin/ on linux, and only in paths containing cygwin, mingw or msys on windows
-- **Improvement**: If the build path contains whitespaces the extension's experimental code runner is used instead of Makefile
+- **Improvement**: If the build path contains whitespaces or non-extended ascii chars the extension's experimental code runner is used instead of Makefile
 
 ## Version 1.2.0: August 25, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Improvement**: Update gcc/clang search logic, to only search in */usr/* and */usr/bin/* on linux, and only in paths containing cygwin, mingw or msys on windows
 - **Improvement**: If the build path contains whitespaces or non-extended ascii chars the extension's experimental code runner is used instead of Makefile
+- **Bugfix**: Fixed using incorrect compiler path in experimental setting
 
 ## Version 1.2.0: August 25, 2021
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,13 @@ You do not need to know about any compiler and Makefile commands. 😎
 
 ## Install the Software Requirements (optional)
 
-- 🖥️ Windows: Highly recommended to install gcc/g++, gdb and make via [Cygwin](https://www.cygwin.com/). Alternatives to this are [MinGW](http://mingw-w64.org/doku.php) or MinGW via [MSYS2](https://www.msys2.org/).
+- 🖥️ Windows: Highly recommended to install gcc/g++, gdb and make via [Cygwin](https://www.cygwin.com/). Alternatives to this is MinGW via [MSYS2](https://www.msys2.org/).
 - 🖥️ Linux: Recommended to install gcc/g++, gdb and make via a package manager (e.g. `apt` for Debian derivates).
 - 🖥️ MacOS: Recommended to install clang/clang++, lldb and make via [xcode-tools](https://developer.apple.com/xcode/features/). An alternative is installing the llvm toolchain with [brew](https://apple.stackexchange.com/a/362837).
 
 ## How to use
 
 1️⃣ The first step is to select the folder that contains the C/C++ files you want to compile, run or debug.  
-For requirements on path and file names see [here](#Constraints-on-Files-and-Folders).  
 You can select the folder by the quick pick menu from the status bar.  
 ![TaskStatusBar](./media/FolderStatusBar.png)  
 Besides that, you can also select a folder by right-clicking in the context menu.  
@@ -54,7 +53,7 @@ Then you can use the different commands in vscode's command palette:
 ### Configuration
 
 The extension will automatically search for an installed compiler on your computer.  
-If any GCC or Clang compiler can be found in the PATH variables this will be set as the compiler.  
+For linux and mac it searches in */bin/* and */usr/bin/*, and on windows it searches for *cygwin*, *mingw* and *msys2* in the PATH.  
 All settings will be stored to the local workspace settings (*".vscode/settings.json"*).  
 If you wish to use any other compiler or different setting, just edit the entries in the local settings file.  
 ![FoundCompiler](./media/FoundCompiler.png)  
@@ -115,8 +114,8 @@ For more information about glob pattern see [here](https://en.wikipedia.org/wiki
 - 📁 The folder selection menu will not list:
   - Folder names including '.' (e.g. *.vscode*), '\_\_' (e.g. temp folders) or 'CMake'
   - The folder named *build* since this is the auto generated folder by this extension
-- 📝 The path and file names shall not contain whitespaces since Makefile can not handle this properly.
-- 📝 The path and file names shall only contain ASCII or UTF-8 characters.
+- 📝 Path and file names containing whitespaces will use the extension's experimental code runner and not Makefile.
+- 📝 Path and file names containing non ASCII characters will use the extension's experimental code runner and not Makefile.
 
 ### CMake and Makefile Projects
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You do not need to know about any compiler and Makefile commands. 😎
 
 ## Install the Software Requirements (optional)
 
-- 🖥️ Windows: Highly recommended to install gcc/g++, gdb and make via [Cygwin](https://www.cygwin.com/). Alternatives to this is MinGW via [MSYS2](https://www.msys2.org/).
+- 🖥️ Windows: Highly recommended to install gcc/g++, gdb and make via [Cygwin](https://www.cygwin.com/). An alternative to this is MinGW via [MSYS2](https://www.msys2.org/).
 - 🖥️ Linux: Recommended to install gcc/g++, gdb and make via a package manager (e.g. `apt` for Debian derivates).
 - 🖥️ MacOS: Recommended to install clang/clang++, lldb and make via [xcode-tools](https://developer.apple.com/xcode/features/). An alternative is installing the llvm toolchain with [brew](https://apple.stackexchange.com/a/362837).
 
@@ -53,8 +53,8 @@ Then you can use the different commands in vscode's command palette:
 ### Configuration
 
 The extension will automatically search for an installed compiler on your computer.  
-For linux and mac it searches in */bin/* and */usr/bin/*, and on windows it searches for *cygwin*, *mingw* and *msys2* in the PATH.  
-All settings will be stored to the local workspace settings (*".vscode/settings.json"*).  
+For linux and mac it searches in */bin/* and */usr/bin/*, and on windows it searches for *cygwin*, *mingw*, and *msys2* in the PATH.  
+All settings will be stored in the local workspace settings (*".vscode/settings.json"*).  
 If you wish to use any other compiler or different setting, just edit the entries in the local settings file.  
 ![FoundCompiler](./media/FoundCompiler.png)  
 
@@ -100,8 +100,8 @@ For more information about glob pattern see [here](https://en.wikipedia.org/wiki
 - ⚙️ What warnings should be checked by the compiler (defaults to ['-Wall', '-Wextra', '-Wpedantic'])
 - ⚙️ To treat warnings as errors (defaults to False)
 - ⚙️ Additional compiler arguments (defaults to [])
-- ⚙️ Additional linker arguments (defaults to []). It is expected to prefix the arguments with the appropiate flags (e.g. -l or -L)
-- ⚙️ Additional include paths (defaults to []) It is **not** (!) expected to prefix the arguments with the appropiate **-I** flag
+- ⚙️ Additional linker arguments (defaults to []). It is expected to prefix the arguments with the appropriate flags (e.g. -l or -L)
+- ⚙️ Additional include paths (defaults to []) It is **not** (!) expected to prefix the arguments with the appropriate **-I** flag
 - ⚙️ Glob pattern to exclude from the folder selection (defaults to [])
 - ⚙️ Experimental: Run compiler commands without Makefile (defaults to False)
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ For more information about glob pattern see [here](https://en.wikipedia.org/wiki
 - 📁 The folder selection menu will not list:
   - Folder names including '.' (e.g. *.vscode*), '\_\_' (e.g. temp folders) or 'CMake'
   - The folder named *build* since this is the auto generated folder by this extension
-- 📝 Path and file names containing whitespaces will use the extension's experimental code runner and not Makefile.
-- 📝 Path and file names containing non ASCII characters will use the extension's experimental code runner and not Makefile.
+- 📝 Paths containing whitespaces or non-extended ASCII characters will use the extension's experimental code runner and not Makefile.
+- 📝 It is forbidden to use spaces in filenames because Makefile cannot handle this properly
 
 ### CMake and Makefile Projects
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "c-cpp-runner",
   "displayName": "C/C++ Runner",
   "description": "🚀 Compile, run and debug single or multiple C/C++ files with ease. 🚀",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "publisher": "franneck94",
   "license": "MIT",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "c-cpp-runner",
   "displayName": "C/C++ Runner",
   "description": "🚀 Compile, run and debug single or multiple C/C++ files with ease. 🚀",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "publisher": "franneck94",
   "license": "MIT",
   "icon": "icon.png",

--- a/src/executor/builder.ts
+++ b/src/executor/builder.ts
@@ -10,13 +10,7 @@ import {
 	mkdirRecursive,
 	pathExists,
 } from '../utils/fileUtils';
-import {
-	Builds,
-	Compilers,
-	Languages,
-	OperatingSystems,
-	Task,
-} from '../utils/types';
+import { Builds, Languages, OperatingSystems, Task } from '../utils/types';
 
 export async function executeBuildTask(
   task: Task,
@@ -43,14 +37,14 @@ export async function executeBuildTask(
 
   const executablePath = path.join(modeDir, executableName);
 
-  let compiler: string | Compilers | undefined;
+  let compiler: string | undefined;
   let standard: string | undefined;
 
   if (language === Languages.cpp) {
-    compiler = settingsProvider.cppCompiler;
+    compiler = settingsProvider.cppCompilerPath;
     standard = settingsProvider.cppStandard;
   } else {
-    compiler = settingsProvider.cCompiler;
+    compiler = settingsProvider.cCompilerPath;
     standard = settingsProvider.cStandard;
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -540,7 +540,7 @@ function initBuildStatusBar(context: vscode.ExtensionContext) {
 
       if (!settingsProvider) return;
 
-      if (experimentalExecutionEnabled) {
+      if (experimentalExecutionEnabled || buildDir.includes(' ')) {
         await executeBuildTask(
           buildTask,
           settingsProvider,
@@ -605,7 +605,7 @@ function initRunStatusBar(context: vscode.ExtensionContext) {
         return;
       }
 
-      if (experimentalExecutionEnabled) {
+      if (experimentalExecutionEnabled || buildDir.includes(' ')) {
         await executeRunTask(
           runTask,
           activeFolder,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -540,7 +540,15 @@ function initBuildStatusBar(context: vscode.ExtensionContext) {
 
       if (!settingsProvider) return;
 
-      if (experimentalExecutionEnabled || buildDir.includes(' ')) {
+      const hasNoneExtendedAsciiChars = [...buildDir].some(
+        (char) => char.charCodeAt(0) > 255,
+      );
+
+      if (
+        experimentalExecutionEnabled ||
+        buildDir.includes(' ') ||
+        hasNoneExtendedAsciiChars
+      ) {
         await executeBuildTask(
           buildTask,
           settingsProvider,
@@ -605,7 +613,15 @@ function initRunStatusBar(context: vscode.ExtensionContext) {
         return;
       }
 
-      if (experimentalExecutionEnabled || buildDir.includes(' ')) {
+      const hasNoneExtendedAsciiChars = [...buildDir].some(
+        (char) => char.charCodeAt(0) > 255,
+      );
+
+      if (
+        experimentalExecutionEnabled ||
+        buildDir.includes(' ') ||
+        hasNoneExtendedAsciiChars
+      ) {
         await executeRunTask(
           runTask,
           activeFolder,

--- a/src/provider/settingsProvider.ts
+++ b/src/provider/settingsProvider.ts
@@ -308,7 +308,7 @@ export class SettingsProvider extends FileProvider {
       } else {
         paths = env.PATH.split(':');
       }
-      for (const env_path of paths) {
+      for (const envPath of paths) {
         if (
           (this._commands.foundGcc &&
             this._commands.foundGpp &&
@@ -319,30 +319,69 @@ export class SettingsProvider extends FileProvider {
         ) {
           break;
         }
-        if (env_path.includes('bin')) {
-          if (this.operatingSystem === OperatingSystems.windows) {
-            this.searchPathVariablesWindows(env_path);
-          } else if (this.operatingSystem === OperatingSystems.linux) {
-            this.searchPathVariablesLinux(env_path);
-          } else if (this.operatingSystem === OperatingSystems.mac) {
-            this.searchPathVariablesMac(env_path);
-          }
+
+        if (this.operatingSystem === OperatingSystems.windows) {
+          if (this.skipCheckWindows(envPath)) continue;
+        } else if (this.operatingSystem === OperatingSystems.linux) {
+          if (this.skipCheckLinux(envPath)) continue;
+        } else if (this.operatingSystem === OperatingSystems.mac) {
+          if (this.skipCheckMac(envPath)) continue;
+        }
+
+        if (this.operatingSystem === OperatingSystems.windows) {
+          this.searchPathVariablesWindows(envPath);
+        } else if (this.operatingSystem === OperatingSystems.linux) {
+          this.searchPathVariablesLinux(envPath);
+        } else if (this.operatingSystem === OperatingSystems.mac) {
+          this.searchPathVariablesMac(envPath);
         }
       }
     }
   }
 
-  private searchPathVariablesWindows(env_path: string) {
-    const lower_path = env_path.toLocaleLowerCase();
+  private skipCheckWindows(envPath: string) {
+    if (
+      !envPath.toLowerCase().includes('bin') &&
+      !envPath.toLowerCase().includes('mingw') &&
+      !envPath.toLowerCase().includes('msys') &&
+      !envPath.toLowerCase().includes('cygwin')
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private skipCheckLinux(envPath: string) {
+    if (
+      !envPath.toLowerCase().startsWith('/bin') &&
+      !envPath.toLowerCase().startsWith('/usr/bin')
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private skipCheckMac(envPath: string) {
+    if (!envPath.toLowerCase().includes('bin')) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private searchPathVariablesWindows(envPath: string) {
+    const lower_path = envPath.toLocaleLowerCase();
     if (
       lower_path.includes(CompilerSystems.cygwin) ||
       lower_path.includes(CompilerSystems.mingw) ||
       lower_path.includes(CompilerSystems.msys2)
     ) {
-      this._commands.pathGcc = path.join(env_path, Compilers.gcc + '.exe');
-      this._commands.pathGpp = path.join(env_path, Compilers.gpp + '.exe');
-      this._commands.pathGDB = path.join(env_path, Debuggers.gdb + '.exe');
-      this._commands.pathMake = path.join(env_path, Makefiles.make + '.exe');
+      this._commands.pathGcc = path.join(envPath, Compilers.gcc + '.exe');
+      this._commands.pathGpp = path.join(envPath, Compilers.gpp + '.exe');
+      this._commands.pathGDB = path.join(envPath, Debuggers.gdb + '.exe');
+      this._commands.pathMake = path.join(envPath, Makefiles.make + '.exe');
 
       if (pathExists(this._commands.pathGcc)) {
         this._commands.foundGcc = true;
@@ -356,20 +395,20 @@ export class SettingsProvider extends FileProvider {
       if (pathExists(this._commands.pathMake)) {
         this._commands.foundMake = true;
       } else {
-        const altpathMake = path.join(env_path, Makefiles.make_mingw + '.exe');
+        const altPathMake = path.join(envPath, Makefiles.make_mingw + '.exe');
 
-        if (pathExists(altpathMake)) {
+        if (pathExists(altPathMake)) {
           this._commands.foundMake = true;
         }
       }
     }
   }
 
-  private searchPathVariablesLinux(env_path: string) {
-    this._commands.pathGcc = path.join(env_path, Compilers.gcc);
-    this._commands.pathGpp = path.join(env_path, Compilers.gpp);
-    this._commands.pathGDB = path.join(env_path, Debuggers.gdb);
-    this._commands.pathMake = path.join(env_path, Makefiles.make);
+  private searchPathVariablesLinux(envPath: string) {
+    this._commands.pathGcc = path.join(envPath, Compilers.gcc);
+    this._commands.pathGpp = path.join(envPath, Compilers.gpp);
+    this._commands.pathGDB = path.join(envPath, Debuggers.gdb);
+    this._commands.pathMake = path.join(envPath, Makefiles.make);
 
     if (pathExists(this._commands.pathGcc)) {
       this._commands.foundGcc = true;
@@ -385,11 +424,11 @@ export class SettingsProvider extends FileProvider {
     }
   }
 
-  private searchPathVariablesMac(env_path: string) {
-    this._commands.pathClang = path.join(env_path, Compilers.clang);
-    this._commands.pathClangpp = path.join(env_path, Compilers.clangpp);
-    this._commands.pathLLDB = path.join(env_path, Debuggers.lldb);
-    this._commands.pathMake = path.join(env_path, Makefiles.make);
+  private searchPathVariablesMac(envPath: string) {
+    this._commands.pathClang = path.join(envPath, Compilers.clang);
+    this._commands.pathClangpp = path.join(envPath, Compilers.clangpp);
+    this._commands.pathLLDB = path.join(envPath, Debuggers.lldb);
+    this._commands.pathMake = path.join(envPath, Makefiles.make);
 
     if (pathExists(this._commands.pathClang)) {
       this._commands.foundClang = true;

--- a/test/integrationTest/testAssets/testPrettyPrint/main.cc
+++ b/test/integrationTest/testAssets/testPrettyPrint/main.cc
@@ -1,7 +1,5 @@
 #include <string>
 
-#define _GLIBCXX_USE_CXX11_ABI 0
-
 void test(const std::string &s)
 {
     s[0];

--- a/test/integrationTest/testAssets/testÜunicodeढ/main.c
+++ b/test/integrationTest/testAssets/testÜunicodeढ/main.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+int main()
+{
+#ifndef NDEBUG
+    printf("Debug Mode");
+#else
+    printf("Release Mode");
+#endif
+
+    return 0;
+}


### PR DESCRIPTION
## Version 1.3.0: August 28, 2021

- **Improvement**: Update gcc/clang search logic, to only search in */usr/* and */usr/bin/* on linux, and only in paths containing cygwin, mingw or msys on windows
- **Improvement**: If the build path contains whitespaces or non-extended ascii chars the extension's experimental code runner is used instead of Makefile
- **Bugfix**: Fixed using incorrect compiler path in experimental setting