### PR TITLE
Dev/1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,19 @@
 
 ## Planned
 
-- Add reset option for settings and properties file
-- If workspace is opened with existing c_cpp_properties file but this extension was not initialized yet in the workspace, use the settings from the properties file
+- If the workspace is opened with existing c_cpp_properties file but this extension was not initialized yet in the workspace, use the settings from the properties file
 
 ## Version 1.4.0: September 16, 2021
 
 - **Improvement**: Updated activation/deactivation logic with the previously called keybinding *toggleStatusBar* which is now called *toggleExtensionState*. By this command, you can de-/activate the extension for the current workspace. If the extension is deactivated, the setting/properties/launch files won't be re-created on delete.
 - **Improvement**: In a workspace with multiple sub-directories, and hence the active folder is not selected on start-up, the settings and properties files are created once the active folder is selected. This speeds up the start-up time for vscode with this extension activated and makes no difference in the usage of this extension.
+- **Improvement**: - Added command to reset local settings and properties file
 
 ## Version 1.3.0: August 28, 2021
 
-- **Improvement**: Update gcc/clang search logic, to only search in */usr/* and */usr/bin/* on linux, and only in paths containing cygwin, mingw or msys on windows
-- **Improvement**: If the build path contains whitespaces or non-extended ascii chars the extension's experimental code runner is used instead of Makefile
-- **Bugfix**: Fixed using incorrect compiler path in experimental setting
+- **Improvement**: Update gcc/clang search logic, to only search in */usr/* and */usr/bin/* on linux, and only in paths containing cygwin, mingw, or msys on windows
+- **Improvement**: If the build path contains whitespaces or non-extended ASCII chars the extension's experimental code runner is used instead of Makefile
+- **Bugfix**: Fixed using incorrect compiler path in the experimental setting
 
 ## Version 1.2.0: August 25, 2021
 
@@ -40,7 +40,7 @@
 
 ## Version 1.1.1: July 26, 2021
 
-- **Improvement**: Creating and deleting build folder is now executed by the extension code and not anymore by the Makefile
+- **Improvement**: Creating and deleting the build folder is now executed by the extension code and not anymore by the Makefile
 
 ## Version 1.1.0: July 24, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Planned
 
 - Add reset option for settings and properties file
-- Add build mode: RelWithDebInfo (-O2 -g -DNDEBUG), MinSizeRel (-Os -DNDEBUG)
 - If workspace is opened with existing c_cpp_properties file but this extension was not initialized yet in the workspace, use the settings from the properties file
 
 ## Version 1.4.0: September 16, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # C/C++ Runner Change Log
 
+## Version 1.4.0
+
+- Add reset option for settings and properties file
+- Add build mode: RelWithDebInfo (-O2 -g -DNDEBUG), MinSizeRel (-Os -DNDEBUG)
+- If workspace is opened with existing c_cpp_properties file but this extension was not initialized yet in the workspace, use the settings from the properties file
+
 ## Version 1.3.0: August 28, 2021
 
 - **Improvement**: Update gcc/clang search logic, to only search in */usr/* and */usr/bin/* on linux, and only in paths containing cygwin, mingw or msys on windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## Planned
 
 - If the workspace is opened with existing c_cpp_properties file but this extension was not initialized yet in the workspace, use the settings from the properties file
+- For Windows MinGW user, the experimental settings (compiling without Makefile) is now the standard.
 
-## Version 1.4.0: September 16, 2021
+## Version 1.4.0: September 18, 2021
 
 - **Improvement**: Updated activation/deactivation logic with the previously called keybinding *toggleStatusBar* which is now called *toggleExtensionState*. By this command, you can de-/activate the extension for the current workspace. If the extension is deactivated, the setting/properties/launch files won't be re-created on delete.
 - **Improvement**: In a workspace with multiple sub-directories, and hence the active folder is not selected on start-up, the settings and properties files are created once the active folder is selected. This speeds up the start-up time for vscode with this extension activated and makes no difference in the usage of this extension.
-- **Improvement**: - Added command to reset local settings and properties file
+- **Improvement**: Added command to reset local settings and properties file
+- **Bugfix**: Fixed issue for Windows PowerShell users with the experimental setting. Now the CMD is also used to execute the tasks even if the PowerShell is the default terminal.
 
 ## Version 1.3.0: August 28, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # C/C++ Runner Change Log
 
-## Version 1.4.0
+## Planned
 
 - Add reset option for settings and properties file
 - Add build mode: RelWithDebInfo (-O2 -g -DNDEBUG), MinSizeRel (-Os -DNDEBUG)
 - If workspace is opened with existing c_cpp_properties file but this extension was not initialized yet in the workspace, use the settings from the properties file
+
+## Version 1.4.0: September 16, 2021
+
+- **Improvement**: Updated activation/deactivation logic with the previously called keybinding *toggleStatusBar* which is now called *toggleExtensionState*. By this command, you can de-/activate the extension for the current workspace. If the extension is deactivated, the setting/properties/launch files won't be re-created on delete.
+- **Improvement**: In a workspace with multiple sub-directories, and hence the active folder is not selected on start-up, the settings and properties files are created once the active folder is selected. This speeds up the start-up time for vscode with this extension activated and makes no difference in the usage of this extension.
 
 ## Version 1.3.0: August 28, 2021
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ After selecting the folder, the icons for building, running, and debugging are s
 
 ### Alternative Usage
 
-If you do not want to see the status bar items you can toggle the visibility with the command `crtl+alt+r`.  
-Then you can use the different commands in vscode's command palette:
+Cou can use the different commands also from vscode's command palette:
 
 ![TaskQuickBar](./media/CommandPalette.png)
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ For more information about glob pattern see [here](https://en.wikipedia.org/wiki
 - ⚙️ To enable warnings (defaults to True)
 - ⚙️ What warnings should be checked by the compiler (defaults to ['-Wall', '-Wextra', '-Wpedantic'])
 - ⚙️ To treat warnings as errors (defaults to False)
-- ⚙️ Additional compiler arguments (defaults to [])
-- ⚙️ Additional linker arguments (defaults to []). It is expected to prefix the arguments with the appropriate flags (e.g. -l or -L)
-- ⚙️ Additional include paths (defaults to []) It is **not** (!) expected to prefix the arguments with the appropriate **-I** flag
+- ⚙️ Additional compiler arguments (defaults to [] e.g. **-flto**)
+- ⚙️ Additional linker arguments (defaults to [] e.g. **-lpthread**). It **is** expected to prefix the arguments with the appropriate flags (e.g. -l or -L)
+- ⚙️ Additional include paths (defaults to [] e.g. **path/to/headers/**) It is **not** (!) expected to prefix the arguments with the **-I** flag
 - ⚙️ Glob pattern to exclude from the folder selection (defaults to [])
 - ⚙️ Experimental: Run compiler commands without Makefile (defaults to False)
 

--- a/package.json
+++ b/package.json
@@ -89,16 +89,19 @@
       {
         "command": "C_Cpp_Runner.folderContextMenu",
         "title": "Select folder from context menu",
-        "when": "C_Cpp_Runner:activatedExtension"
+        "when": "C_Cpp_Runner:activatedExtension",
+        "category": "C/C++ Runner"
       },
       {
         "command": "C_Cpp_Runner.resetLocalSettings",
-        "title": "Reset the local settings and properties",
-        "when": "C_Cpp_Runner:activatedExtension"
+        "title": "Reset local settings",
+        "when": "C_Cpp_Runner:activatedExtension",
+        "category": "C/C++ Runner"
       },
       {
         "command": "C_Cpp_Runner.toggleExtensionState",
-        "title": "Activate/Deactivate the extension"
+        "title": "Activate/Deactivate the extension",
+        "category": "C/C++ Runner"
       },
       {
         "command": "C_Cpp_Runner.args",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "^1.57.0"
+    "vscode": "^1.58.0"
   },
   "categories": [
     "Programming Languages",
@@ -89,6 +89,11 @@
       {
         "command": "C_Cpp_Runner.folderContextMenu",
         "title": "Select folder from context menu",
+        "when": "C_Cpp_Runner:activatedExtension"
+      },
+      {
+        "command": "C_Cpp_Runner.resetLocalSettings",
+        "title": "Reset the local settings and properties",
         "when": "C_Cpp_Runner:activatedExtension"
       },
       {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "c-cpp-runner",
   "displayName": "C/C++ Runner",
   "description": "🚀 Compile, run and debug single or multiple C/C++ files with ease. 🚀",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "publisher": "franneck94",
   "license": "MIT",
   "icon": "icon.png",
@@ -92,9 +92,8 @@
         "when": "C_Cpp_Runner:activatedExtension"
       },
       {
-        "command": "C_Cpp_Runner.toggleStatusBar",
-        "title": "Toggle status bar icons",
-        "when": "C_Cpp_Runner:activatedExtension"
+        "command": "C_Cpp_Runner.toggleExtensionState",
+        "title": "Activate/Deactivate the extension"
       },
       {
         "command": "C_Cpp_Runner.args",
@@ -105,10 +104,9 @@
     ],
     "keybindings": [
       {
-        "command": "C_Cpp_Runner.toggleStatusBar",
+        "command": "C_Cpp_Runner.toggleExtensionState",
         "key": "ctrl+alt+r",
-        "mac": "ctrl+alt+r",
-        "when": "C_Cpp_Runner:activatedExtension"
+        "mac": "ctrl+alt+r"
       },
       {
         "command": "C_Cpp_Runner.args",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -301,10 +301,10 @@ function initConfigurationChangeDisposable() {
       const extensionIsActive = getActivationState();
 
       if (isChanged && extensionIsActive) {
-        if (settingsProvider) settingsProvider.updateFileContent();
-        if (propertiesProvider) propertiesProvider.updateFileContent();
-        if (launchProvider) launchProvider.updateFileContent();
-        if (taskProvider) taskProvider.getTasks();
+        settingsProvider?.updateFileContent();
+        propertiesProvider?.updateFileContent();
+        launchProvider?.updateFileContent();
+        taskProvider?.getTasks();
       }
     },
   );
@@ -373,19 +373,19 @@ function initFileDeleteDisposable() {
 
 function toggleStatusBarItems() {
   if (showStatusBarItems) {
-    if (folderStatusBar) folderStatusBar.show();
-    if (modeStatusBar && activeFolder) modeStatusBar.show();
-    if (buildStatusBar && activeFolder) buildStatusBar.show();
-    if (runStatusBar && activeFolder) runStatusBar.show();
-    if (debugStatusBar && activeFolder) debugStatusBar.show();
-    if (cleanStatusBar && activeFolder) cleanStatusBar.show();
+    folderStatusBar?.show();
+    modeStatusBar?.show();
+    buildStatusBar?.show();
+    runStatusBar?.show();
+    debugStatusBar?.show();
+    cleanStatusBar?.show();
   } else {
-    if (folderStatusBar) folderStatusBar.hide();
-    if (modeStatusBar) modeStatusBar.hide();
-    if (buildStatusBar) buildStatusBar.hide();
-    if (runStatusBar) runStatusBar.hide();
-    if (debugStatusBar) debugStatusBar.hide();
-    if (cleanStatusBar) cleanStatusBar.hide();
+    folderStatusBar?.hide();
+    modeStatusBar?.hide();
+    buildStatusBar?.hide();
+    runStatusBar?.hide();
+    debugStatusBar?.hide();
+    cleanStatusBar?.hide();
   }
 }
 
@@ -441,8 +441,6 @@ function updateFolderData() {
     updateDebugStatus(debugStatusBar, showStatusBarItems, activeFolder);
   }
 }
-
-// INIT STATUS BAR
 
 function initFolderStatusBar() {
   if (folderStatusBar) return;
@@ -563,9 +561,9 @@ function initReset() {
 
       settingsProvider.reset();
 
-      if (!taskProvider) return;
-
-      taskProvider.getTasks();
+      propertiesProvider?.updateFileContent();
+      taskProvider?.getTasks();
+      launchProvider?.updateFileContent();
     },
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,9 +102,6 @@ export function activate(context: vscode.ExtensionContext) {
     workspaceFolder = vscode.workspace.workspaceFolders[0].uri.fsPath;
   }
 
-  setContextValue(`${EXTENSION_NAME}:activatedExtension`, true);
-  updateActivationState(true);
-
   const courseMakefileFound = isCourseProject();
 
   if (courseMakefileFound) {
@@ -128,6 +125,8 @@ export function activate(context: vscode.ExtensionContext) {
   updateLoggingState();
   loggingActive = getLoggingState();
   experimentalExecutionEnabled = getExperimentalExecutionState();
+  setContextValue(`${EXTENSION_NAME}:activatedExtension`, true);
+  updateActivationState(true);
 
   initFolderStatusBar();
   initModeStatusBar();
@@ -623,11 +622,12 @@ function initBuildStatusBar() {
         (char) => char.charCodeAt(0) > 255,
       );
 
-      if (
+      const nonMakefileCommand =
         experimentalExecutionEnabled ||
         buildDir.includes(' ') ||
-        hasNoneExtendedAsciiChars
-      ) {
+        hasNoneExtendedAsciiChars;
+
+      if (nonMakefileCommand) {
         await executeBuildTask(
           buildTask,
           settingsProvider,
@@ -698,11 +698,12 @@ function initRunStatusBar() {
         (char) => char.charCodeAt(0) > 255,
       );
 
-      if (
+      const nonMakefileCommand =
         experimentalExecutionEnabled ||
         buildDir.includes(' ') ||
-        hasNoneExtendedAsciiChars
-      ) {
+        hasNoneExtendedAsciiChars;
+
+      if (nonMakefileCommand) {
         await executeRunTask(
           runTask,
           activeFolder,

--- a/src/handler/folderHandler.ts
+++ b/src/handler/folderHandler.ts
@@ -1,9 +1,9 @@
-import * as minimatch from 'minimatch';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
 import { SettingsProvider } from '../provider/settingsProvider';
 import {
+	excludePatternFromList,
 	getDirectoriesRecursive,
 	naturalSort,
 	replaceBackslashes,
@@ -31,11 +31,10 @@ export async function folderHandler(
     });
 
     if (settingsProvider) {
-      for (const pattern of settingsProvider.excludeSearch) {
-        foldersList = foldersList.filter(
-          (folder) => !minimatch(folder, pattern),
-        );
-      }
+      foldersList = excludePatternFromList(
+        settingsProvider.excludeSearch,
+        foldersList,
+      );
     }
 
     foldersList = naturalSort(foldersList);

--- a/src/provider/callbackProvider.ts
+++ b/src/provider/callbackProvider.ts
@@ -16,6 +16,7 @@ export abstract class CallbackProvider {
   ) {
     this._vscodeDirectory = path.join(this._workspaceFolder, '.vscode');
     this._outputPath = path.join(this._vscodeDirectory, outputFileName);
+
     this.createFileWatcher();
   }
 
@@ -57,11 +58,7 @@ export abstract class CallbackProvider {
     return;
   }
 
-  public deleteCallback() {
-    throw new Error('Not implemented error.');
-  }
+  public abstract deleteCallback(): void;
 
-  public changeCallback() {
-    throw new Error('Not implemented error.');
-  }
+  public abstract changeCallback(): void;
 }

--- a/src/provider/callbackProvider.ts
+++ b/src/provider/callbackProvider.ts
@@ -1,6 +1,8 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 
+import { getActivationState } from '../utils/vscodeUtils';
+
 export abstract class CallbackProvider {
   protected _outputPath: string;
   protected _vscodeDirectory: string;
@@ -12,7 +14,6 @@ export abstract class CallbackProvider {
     protected templateFileName: string,
     protected outputFileName: string,
   ) {
-    this._workspaceFolder = _workspaceFolder;
     this._vscodeDirectory = path.join(this._workspaceFolder, '.vscode');
     this._outputPath = path.join(this._vscodeDirectory, outputFileName);
     this.createFileWatcher();
@@ -41,7 +42,8 @@ export abstract class CallbackProvider {
     this._fileWatcherOnDelete.onDidDelete((e: vscode.Uri) => {
       const pathName = e.fsPath;
       if (pathName === this._vscodeDirectory || pathName === this._outputPath) {
-        this.deleteCallback();
+        const extensionIsActive = getActivationState();
+        if (extensionIsActive) this.deleteCallback();
       }
     });
 

--- a/src/provider/fileProvider.ts
+++ b/src/provider/fileProvider.ts
@@ -10,8 +10,8 @@ export abstract class FileProvider extends CallbackProvider {
 
   constructor(
     workspaceFolder: string,
-    protected templateFileName: string,
-    protected outputFileName: string,
+    templateFileName: string,
+    outputFileName: string,
   ) {
     super(workspaceFolder, templateFileName, outputFileName);
 
@@ -26,13 +26,9 @@ export abstract class FileProvider extends CallbackProvider {
     }
   }
 
-  protected updateCheck() {
-    return false;
-  }
+  protected abstract updateCheck(): boolean;
 
-  public writeFileData() {
-    throw new Error('Not implemented error.');
-  }
+  public abstract writeFileData(): void;
 
   public createFileData() {
     if (!pathExists(this._vscodeDirectory)) {
@@ -46,7 +42,7 @@ export abstract class FileProvider extends CallbackProvider {
     this.writeFileData();
   }
 
-  public deleteCallback() {
+  public override deleteCallback() {
     const extensionIsActive = getActivationState();
     if (extensionIsActive) this.createFileData();
   }

--- a/src/provider/fileProvider.ts
+++ b/src/provider/fileProvider.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 
 import { extensionPath } from '../extension';
 import { mkdirRecursive, pathExists } from '../utils/fileUtils';
+import { getActivationState } from '../utils/vscodeUtils';
 import { CallbackProvider } from './callbackProvider';
 
 export abstract class FileProvider extends CallbackProvider {
@@ -46,7 +47,8 @@ export abstract class FileProvider extends CallbackProvider {
   }
 
   public deleteCallback() {
-    this.createFileData();
+    const extensionIsActive = getActivationState();
+    if (extensionIsActive) this.createFileData();
   }
 
   protected _updateFolderData(_workspaceFolder: string) {

--- a/src/provider/launchProvider.ts
+++ b/src/provider/launchProvider.ts
@@ -29,7 +29,9 @@ export class LaunchProvider extends FileProvider {
       this.activeFolder = this.workspaceFolder;
     }
 
-    if (this.updateCheck()) {
+    const updateRequired = this.updateCheck();
+
+    if (updateRequired) {
       this.createFileData();
     }
   }

--- a/src/provider/propertiesProvider.ts
+++ b/src/provider/propertiesProvider.ts
@@ -1,9 +1,9 @@
 import {
-  getBasename,
-  pathExists,
-  readJsonFile,
-  removeExtension,
-  writeJsonFile,
+	getBasename,
+	pathExists,
+	readJsonFile,
+	removeExtension,
+	writeJsonFile,
 } from '../utils/fileUtils';
 import { Compilers, JsonConfiguration, OperatingSystems } from '../utils/types';
 import { FileProvider } from './fileProvider';
@@ -17,10 +17,11 @@ export class PropertiesProvider extends FileProvider {
   constructor(
     protected settings: SettingsProvider,
     public workspaceFolder: string,
+    public activeFolder: string | undefined,
   ) {
     super(workspaceFolder, TEMPLATE_FILENAME, OUTPUT_FILENAME);
 
-    if (this.updateCheck()) {
+    if (this.updateCheck() && activeFolder) {
       this.createFileData();
     }
   }

--- a/src/provider/propertiesProvider.ts
+++ b/src/provider/propertiesProvider.ts
@@ -21,7 +21,9 @@ export class PropertiesProvider extends FileProvider {
   ) {
     super(workspaceFolder, TEMPLATE_FILENAME, OUTPUT_FILENAME);
 
-    if (this.updateCheck() && activeFolder) {
+    const updateRequired = this.updateCheck();
+
+    if (updateRequired && activeFolder) {
       this.createFileData();
     }
   }

--- a/src/provider/settingsProvider.ts
+++ b/src/provider/settingsProvider.ts
@@ -24,6 +24,7 @@ import {
 	Makefiles,
 	OperatingSystems,
 } from '../utils/types';
+import { getActivationState } from '../utils/vscodeUtils';
 import { FileProvider } from './fileProvider';
 
 const TEMPLATE_FILENAME = 'settings_template.json';
@@ -76,12 +77,12 @@ export class SettingsProvider extends FileProvider {
   public warningsAsError: boolean = SettingsProvider.DEFAULT_WARNINGS_AS_ERRORS;
   public warnings: string[] = SettingsProvider.DEFAULT_WARNINGS;
 
-  constructor(public workspaceFolder: string) {
+  constructor(public workspaceFolder: string, public activeFolder: string) {
     super(workspaceFolder, TEMPLATE_FILENAME, OUTPUT_FILENAME);
 
-    if (this.updateCheck()) {
+    if (this.updateCheck() && activeFolder) {
       this.createFileData();
-    } else {
+    } else if (activeFolder) {
       this.getSettings();
       this.getCommandTypes();
       this.getArchitecture();
@@ -145,7 +146,8 @@ export class SettingsProvider extends FileProvider {
   }
 
   public deleteCallback() {
-    this.writeFileData();
+    const extensionIsActive = getActivationState();
+    if (extensionIsActive) this.writeFileData();
   }
 
   public changeCallback() {

--- a/src/provider/settingsProvider.ts
+++ b/src/provider/settingsProvider.ts
@@ -80,7 +80,9 @@ export class SettingsProvider extends FileProvider {
   constructor(public workspaceFolder: string, public activeFolder: string) {
     super(workspaceFolder, TEMPLATE_FILENAME, OUTPUT_FILENAME);
 
-    if (this.updateCheck() && activeFolder) {
+    const updateRequired = this.updateCheck();
+
+    if (updateRequired && activeFolder) {
       this.createFileData();
     } else if (activeFolder) {
       this.getSettings();
@@ -89,7 +91,7 @@ export class SettingsProvider extends FileProvider {
     }
   }
 
-  protected updateCheck() {
+  protected override updateCheck() {
     let doUpdate = false;
 
     if (!pathExists(this._outputPath)) {
@@ -145,7 +147,7 @@ export class SettingsProvider extends FileProvider {
     }
   }
 
-  public deleteCallback() {
+  public override deleteCallback() {
     const extensionIsActive = getActivationState();
     if (extensionIsActive) this.writeFileData();
   }
@@ -303,12 +305,12 @@ export class SettingsProvider extends FileProvider {
     this._commands = new Commands();
 
     const env = process.env;
-    if (env.PATH) {
+    if (env['PATH']) {
       let paths: string[] = [];
       if (this.operatingSystem === OperatingSystems.windows) {
-        paths = env.PATH.split(';');
+        paths = env['PATH'].split(';');
       } else {
-        paths = env.PATH.split(':');
+        paths = env['PATH'].split(':');
       }
       for (const envPath of paths) {
         if (
@@ -524,6 +526,32 @@ export class SettingsProvider extends FileProvider {
       this.architecure = Architectures.x64;
       this.isCygwin = false;
     }
+  }
+
+  public reset() {
+    /* Mandatory in settings.json */
+    this.cCompilerPath = SettingsProvider.DEFAULT_C_COMPILER_PATH;
+    this.cppCompilerPath = SettingsProvider.DEFAULT_CPP_COMPILER_PATH;
+    this.debuggerPath = SettingsProvider.DEFAULT_DEBUGGER_PATH;
+    this.makePath = SettingsProvider.DEFAULT_MAKE_PATH;
+
+    /* Optional in settings.json */
+    this.enableWarnings = SettingsProvider.DEFAULT_ENABLE_WARNINGS;
+    this.warnings = SettingsProvider.DEFAULT_WARNINGS;
+    this.warningsAsError = SettingsProvider.DEFAULT_WARNINGS_AS_ERRORS;
+    this.cStandard = SettingsProvider.DEFAULT_C_STANDARD;
+    this.cppStandard = SettingsProvider.DEFAULT_CPP_STANDARD;
+    this.compilerArgs = SettingsProvider.DEFAULT_COMPILER_ARGS;
+    this.linkerArgs = SettingsProvider.DEFAULT_LINKER_ARGS;
+    this.includePaths = SettingsProvider.DEFAULT_INCLUDE_PATHS;
+    this.excludeSearch = SettingsProvider.DEFAULT_EXCLUDE_SEARCH;
+
+    /* Write default settings to file */
+    this.setGcc(this.cCompilerPath);
+    this.setGpp(this.cppCompilerPath);
+    this.setGDB(this.debuggerPath);
+    this.setMake(this.makePath);
+    this.setOtherSettings();
   }
 
   /********************/

--- a/src/provider/taskProvider.ts
+++ b/src/provider/taskProvider.ts
@@ -96,7 +96,21 @@ export class TaskProvider implements vscode.TaskProvider {
       };
       const problemMatcher = '$gcc';
       const scope = vscode.TaskScope.Workspace;
-      const execution = new vscode.ShellExecution(shellCommand);
+      let execution: vscode.ShellExecution;
+
+      if (
+        this._settingsProvider.operatingSystem === OperatingSystems.windows &&
+        this._settingsProvider.isPowershellTerminal
+      ) {
+        const shellOptions: vscode.ShellExecutionOptions = {
+          executable: 'C:/Windows/System32/cmd.exe',
+          shellArgs: ['/d', '/c'],
+        };
+        execution = new vscode.ShellExecution(shellCommand, shellOptions);
+      } else {
+        execution = new vscode.ShellExecution(shellCommand);
+      }
+
       const task = new Task(
         definition,
         scope,

--- a/src/provider/taskProvider.ts
+++ b/src/provider/taskProvider.ts
@@ -282,7 +282,9 @@ export class TaskProvider implements vscode.TaskProvider {
       path.basename(this.workspaceFolder),
     );
     let label = `Debug: ${this.activeFolder}`;
-    label = label.replace(label.split(': ')[1], folder);
+    const splitted = label.split(': ');
+    if (!splitted[1]) return;
+    label = label.replace(splitted[1], folder);
     label = replaceBackslashes(label);
     const definition = {
       type: 'shell',

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as JSON5 from 'json5';
+import * as minimatch from 'minimatch';
 import * as path from 'path';
 
 import { loggingActive } from '../extension';
@@ -123,6 +124,17 @@ export function filesInDir(dir: string) {
     .map((file) => file.name);
 
   return files;
+}
+
+export function excludePatternFromList(
+  excludeSearch: string[],
+  foldersList: string[],
+) {
+  for (const pattern of excludeSearch) {
+    foldersList = foldersList.filter((folder) => !minimatch(folder, pattern));
+  }
+
+  return foldersList;
 }
 
 export function foldersInDir(dir: fs.PathLike) {

--- a/src/utils/systemUtils.ts
+++ b/src/utils/systemUtils.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 import { lookpath } from 'lookpath';
 import { platform } from 'os';
 
-import { Architectures, Compilers, OperatingSystems } from './types';
+import { Architectures, OperatingSystems } from './types';
 
 export async function commandExists(command: string) {
   let commandPath = await lookpath(command);
@@ -33,7 +33,7 @@ export function getOperatingSystem() {
   return operatingSystem;
 }
 
-export function getCompilerArchitecture(compiler: Compilers) {
+export function getCompilerArchitecture(compiler: string) {
   const command = `${compiler} -dumpmachine`;
   let byteArray: Buffer | undefined;
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -21,7 +21,7 @@ export interface JsonTask {
 }
 
 export class Task extends vscode.Task {
-  execution?: vscode.ShellExecution;
+  override execution?: vscode.ShellExecution;
 }
 
 export class Commands {
@@ -91,37 +91,4 @@ export enum Tasks {
   run = 'Run',
   clean = 'Clean',
   debug = 'Debug',
-}
-
-export function isUri(input: any): input is vscode.Uri {
-  return input && input instanceof vscode.Uri;
-}
-
-export function isString(input: any): input is string {
-  return typeof input === 'string';
-}
-
-export function isNumber(input: any): input is number {
-  return typeof input === 'number';
-}
-
-export function isBoolean(input: any): input is boolean {
-  return typeof input === 'boolean';
-}
-
-export function isObject(input: any): input is object {
-  return typeof input === 'object';
-}
-
-export function isArray(input: any): input is any[] {
-  return input instanceof Array;
-}
-
-export function arrayEquals(a: any[], b: any[]) {
-  return (
-    Array.isArray(a) &&
-    Array.isArray(b) &&
-    a.length === b.length &&
-    a.every((val, index) => val === b[index])
-  );
 }

--- a/src/utils/vscodeUtils.ts
+++ b/src/utils/vscodeUtils.ts
@@ -9,9 +9,7 @@ const STATUS_BAR_ALIGN = vscode.StatusBarAlignment.Left;
 const STATUS_BAR_PRIORITY = 50;
 
 export function disposeItem(disposableItem: vscode.Disposable | undefined) {
-  if (disposableItem) {
-    disposableItem.dispose();
-  }
+  disposableItem?.dispose();
 }
 
 export function createStatusBarItem() {
@@ -45,20 +43,16 @@ export function getLaunchConfigIndex(
 }
 
 export function updateLoggingState() {
-  if (extensionState) {
-    extensionState.update(
-      'loggingActive',
-      vscode.workspace
-        .getConfiguration('C_Cpp_Runner')
-        .get('loggingActive', false),
-    );
-  }
+  extensionState?.update(
+    'loggingActive',
+    vscode.workspace
+      .getConfiguration('C_Cpp_Runner')
+      .get('loggingActive', false),
+  );
 }
 
 export function updateActivationState(newState: boolean) {
-  if (extensionState) {
-    extensionState.update('activatedExtension', newState);
-  }
+  extensionState?.update('activatedExtension', newState);
 }
 
 export function getExperimentalExecutionState() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     /* Additional Checks */
     "noUnusedLocals": true,                      /* Report errors on unused locals. */
     "noUnusedParameters": true,                  /* Report errors on unused parameters. */
-    "noImplicitReturns": false,                   /* Report error when not all code paths in function return a value. */
+    "noImplicitReturns": false,                  /* Report error when not all code paths in function return a value. */
     "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
     "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
     "noImplicitOverride": true,                  /* Ensure overriding members in derived classes are marked with an 'override' modifier. */
@@ -30,11 +30,11 @@
 
     /* Module Resolution Options */
     "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                     /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": false,                    /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
 
     /* Advanced Options */
     "skipLibCheck": true,                           /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true,        /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true,       /* Disallow inconsistently-cased references to the same file. */
     "experimentalDecorators": true,
     "resolveJsonModule": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,43 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es2018",
-    "outDir": "dist",
-    "lib": ["es6", "es2018", "dom", "dom.iterable", "ES2019", "ES2020"],
-    "sourceMap": true,
-    "rootDir": ".",
+    /* Basic Options */
+    "target": "ES2020",                             /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "lib": ["es6", "es2018", "dom", "dom.iterable", "ES2019", "ES2020"],                          /* Specify library files to be included in the compilation. */
+    "sourceMap": true,                              /* Generates corresponding '.map' file. */
+    "outDir": "dist",                               /* Redirect output structure to the directory. */
+    "rootDir": "./",                                /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "removeComments": true,                         /* Do not emit comments to output. */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                                 /* Enable all strict type-checking options. */
+    "noImplicitAny": true,                          /* Raise error on expressions and declarations with an implied 'any' type. */
+    "strictNullChecks": true,                       /* Enable strict null checks. */
+    "strictFunctionTypes": true,                    /* Enable strict checking of function types. */
+    "strictBindCallApply": true,                    /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    "strictPropertyInitialization": true,           /* Enable strict checking of property initialization in classes. */
+    "noImplicitThis": true,                         /* Raise error on 'this' expressions with an implied 'any' type. */
+    "alwaysStrict": true,                           /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    "noUnusedLocals": true,                      /* Report errors on unused locals. */
+    "noUnusedParameters": true,                  /* Report errors on unused parameters. */
+    "noImplicitReturns": false,                   /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
+    "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
+    "noImplicitOverride": true,                  /* Ensure overriding members in derived classes are marked with an 'override' modifier. */
+    "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
+
+    /* Module Resolution Options */
+    "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                     /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                           /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true,        /* Disallow inconsistently-cased references to the same file. */
     "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "resolveJsonModule": true,
-    "removeComments": true
+    "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts",],
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", ".vscode", "out", "dist"]
 }


### PR DESCRIPTION
## Version 1.4.0: September 18, 2021

- **Improvement**: Updated activation/deactivation logic with the previously called keybinding *toggleStatusBar* which is now called *toggleExtensionState*. By this command, you can de-/activate the extension for the current workspace. If the extension is deactivated, the setting/properties/launch files won't be re-created on delete.
- **Improvement**: In a workspace with multiple sub-directories, and hence the active folder is not selected on start-up, the settings and properties files are created once the active folder is selected. This speeds up the start-up time for vscode with this extension activated and makes no difference in the usage of this extension.
- **Improvement**: Added command to reset local settings and properties file
- **Bugfix**: Fixed issue for Windows PowerShell users with the experimental setting. Now the CMD is also used to execute the tasks even if the PowerShell is the default terminal.