### PR TITLE
Hot fix for 1.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # C/C++ Runner Change Log
 
-## Version 3.1.2: March 5, 2022
+## Version 3.2.0: March 5, 2022
 
+- **Info**: Now using relative paths for building the binary, hence the console output is shortened and more readable
 - **Bugfix**: Hot fix since extension was not working anymore with VSCode 1.65.0
 
 ## Version 3.1.1: January 31, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # C/C++ Runner Change Log
 
-## Version 3.1.1: January 31, 2021
+## Version 3.1.2: March 5, 2022
+
+- **Bugfix**: Hot fix since extension was not working anymore with VSCode 1.65.0
+
+## Version 3.1.1: January 31, 2022
 
 - **Info**: Updated MSVC instructions
 
-## Version 3.1.0: January 19, 2021
+## Version 3.1.0: January 19, 20212
 
 - **Info**: Removed Makefile deactivation
 - **Info**: Updated README

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ These arguments will be stored in the launch.json config for debugging the binar
 ![ArgumentsDebug](./media/argumentsDebug.png)
 
 If you now run or debug your program these values will be fed into **argc**/**argv**.  
-Note: The stored arguments will be reset after selecting a new active folder.
+The stored arguments will be reset after selecting a new active folder.  
+Note: Do not use ' or " for any arguments.
 
 ### Include & Exclude Folders for Selection
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "c-cpp-runner",
   "displayName": "C/C++ Runner",
   "description": "🚀 Compile, run and debug single or multiple C/C++ files with ease. 🚀",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "publisher": "franneck94",
   "license": "MIT",
   "icon": "icon.png",
@@ -11,7 +11,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "^1.63.0"
+    "vscode": "^1.65.0"
   },
   "categories": [
     "Programming Languages",

--- a/src/executor/builder.ts
+++ b/src/executor/builder.ts
@@ -11,10 +11,10 @@ import {
 	mkdirRecursive,
 	pathExists,
 } from '../utils/fileUtils';
-import { Builds, Languages, OperatingSystems, Task } from '../utils/types';
+import { Builds, Languages, OperatingSystems } from '../utils/types';
 
 export async function executeBuildTask(
-  task: Task,
+  task: vscode.Task,
   settingsProvider: SettingsProvider,
   activeFolder: string,
   buildMode: Builds,
@@ -83,8 +83,13 @@ export async function executeBuildTask(
 
   if (!task || !task.execution || commandLine === undefined) return;
 
+  if (!(task.execution instanceof vscode.ShellExecution)) return;
+
   task.execution.commandLine = commandLine;
+
   await vscode.tasks.executeTask(task);
+
+  await task.execution.
 }
 
 function executeBuildTaskUnixBased(

--- a/src/executor/builder.ts
+++ b/src/executor/builder.ts
@@ -13,8 +13,9 @@ import {
 } from '../utils/fileUtils';
 import { Builds, Languages, OperatingSystems } from '../utils/types';
 
+const EXTENSION_NAME = 'C_Cpp_Runner';
+
 export async function executeBuildTask(
-  task: vscode.Task,
   settingsProvider: SettingsProvider,
   activeFolder: string,
   buildMode: Builds,
@@ -81,15 +82,35 @@ export async function executeBuildTask(
     );
   }
 
-  if (!task || !task.execution || commandLine === undefined) return;
+  if (!commandLine) return;
 
-  if (!(task.execution instanceof vscode.ShellExecution)) return;
+  const task_name = 'Build';
 
-  task.execution.commandLine = commandLine;
+  let execution: vscode.ProcessExecution | undefined;
+  if (settingsProvider.operatingSystem === OperatingSystems.windows) {
+    execution = new vscode.ProcessExecution('C:/Windows/System32/cmd.exe', [
+      '/d',
+      '/c',
+      commandLine,
+    ]);
+  } else {
+    execution = new vscode.ProcessExecution('terminal', [commandLine]);
+  }
+
+  const definition = {
+    type: 'shell',
+    task: task_name,
+  };
+
+  const task = new vscode.Task(
+    definition,
+    vscode.TaskScope.Workspace,
+    task_name,
+    EXTENSION_NAME,
+    execution,
+  );
 
   await vscode.tasks.executeTask(task);
-
-  await task.execution.
 }
 
 function executeBuildTaskUnixBased(

--- a/src/executor/builder.ts
+++ b/src/executor/builder.ts
@@ -93,6 +93,9 @@ export async function executeBuildTask(
       '/c',
       commandLine,
     ]);
+  } else if (settingsProvider.operatingSystem === OperatingSystems.linux) {
+    const env = process.env;
+    execution = new vscode.ProcessExecution('terminal', [commandLine]);
   } else {
     execution = new vscode.ProcessExecution('terminal', [commandLine]);
   }

--- a/src/executor/cleaner.ts
+++ b/src/executor/cleaner.ts
@@ -7,6 +7,7 @@ import {
 	rmdirRecursive,
 } from '../utils/fileUtils';
 import { Builds, OperatingSystems } from '../utils/types';
+import { getProcessExecution } from '../utils/vscodeUtils';
 
 const EXTENSION_NAME = 'C_Cpp_Runner';
 
@@ -31,17 +32,11 @@ export async function executeCleanTask(
 
   const task_name = 'Clean';
 
-  let execution: vscode.ProcessExecution | undefined;
-
-  if (operatingSystem === OperatingSystems.windows) {
-    execution = new vscode.ProcessExecution('C:/Windows/System32/cmd.exe', [
-      '/d',
-      '/c',
-      commandLine,
-    ]);
-  } else {
-    execution = new vscode.ProcessExecution('terminal', [commandLine]);
-  }
+  const execution = getProcessExecution(
+    operatingSystem,
+    commandLine,
+    activeFolder,
+  );
 
   const definition = {
     type: 'shell',

--- a/src/executor/cleaner.ts
+++ b/src/executor/cleaner.ts
@@ -1,0 +1,60 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import {
+	pathExists,
+	replaceBackslashes,
+	rmdirRecursive,
+} from '../utils/fileUtils';
+import { Builds, OperatingSystems } from '../utils/types';
+
+const EXTENSION_NAME = 'C_Cpp_Runner';
+
+export async function executeCleanTask(
+  activeFolder: string,
+  buildMode: Builds,
+  workspaceFolder: string,
+  operatingSystem: OperatingSystems,
+) {
+  const buildDir = path.join(activeFolder, 'build');
+  const modeDir = path.join(buildDir, `${buildMode}`);
+
+  let relativeModeDir = modeDir.replace(workspaceFolder, '');
+  relativeModeDir = replaceBackslashes(relativeModeDir);
+
+  const commandLine = `echo Cleaning ${relativeModeDir}...`;
+
+  if (!pathExists(modeDir)) return;
+
+  rmdirRecursive(modeDir);
+  if (!commandLine) return;
+
+  const task_name = 'Clean';
+
+  let execution: vscode.ProcessExecution | undefined;
+
+  if (operatingSystem === OperatingSystems.windows) {
+    execution = new vscode.ProcessExecution('C:/Windows/System32/cmd.exe', [
+      '/d',
+      '/c',
+      commandLine,
+    ]);
+  } else {
+    execution = new vscode.ProcessExecution('terminal', [commandLine]);
+  }
+
+  const definition = {
+    type: 'shell',
+    task: task_name,
+  };
+
+  const task = new vscode.Task(
+    definition,
+    vscode.TaskScope.Workspace,
+    task_name,
+    EXTENSION_NAME,
+    execution,
+  );
+
+  await vscode.tasks.executeTask(task);
+}

--- a/src/executor/runner.ts
+++ b/src/executor/runner.ts
@@ -2,10 +2,10 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import { pathExists } from '../utils/fileUtils';
-import { Builds, OperatingSystems, Task } from '../utils/types';
+import { Builds, OperatingSystems } from '../utils/types';
 
 export async function executeRunTask(
-  task: Task,
+  task: vscode.Task,
   activeFolder: string,
   buildMode: Builds,
   argumentsString: string | undefined,
@@ -43,7 +43,10 @@ export async function executeRunTask(
   }
 
   if (task && task.execution) {
+    if (!(task.execution instanceof vscode.ShellExecution)) return;
+
     task.execution.commandLine = executableCall;
+
     await vscode.tasks.executeTask(task);
   }
 }

--- a/src/executor/runner.ts
+++ b/src/executor/runner.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 
 import { pathExists } from '../utils/fileUtils';
 import { Builds, OperatingSystems } from '../utils/types';
+import { getProcessExecution } from '../utils/vscodeUtils';
 
 const EXTENSION_NAME = 'C_Cpp_Runner';
 
@@ -47,16 +48,11 @@ export async function executeRunTask(
 
   const task_name = 'Run';
 
-  let execution: vscode.ProcessExecution | undefined;
-  if (operatingSystem === OperatingSystems.windows) {
-    execution = new vscode.ProcessExecution('C:/Windows/System32/cmd.exe', [
-      '/d',
-      '/c',
-      commandLine,
-    ]);
-  } else {
-    execution = new vscode.ProcessExecution('terminal', [commandLine]);
-  }
+  const execution = getProcessExecution(
+    operatingSystem,
+    commandLine,
+    activeFolder,
+  );
 
   const definition = {
     type: 'shell',

--- a/src/executor/runner.ts
+++ b/src/executor/runner.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { SettingsProvider } from '../provider/settingsProvider';
 import { pathExists } from '../utils/fileUtils';
 import { Builds, OperatingSystems } from '../utils/types';
 
@@ -46,7 +45,7 @@ export async function executeRunTask(
 
   if (!commandLine) return;
 
-  const task_name = 'Build';
+  const task_name = 'Run';
 
   let execution: vscode.ProcessExecution | undefined;
   if (operatingSystem === OperatingSystems.windows) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -641,15 +641,17 @@ function initCleanStatusBar() {
 
       if (
         !cleanTask.execution ||
-        !(cleanTask.execution instanceof vscode.ShellExecution) ||
-        !cleanTask.execution.commandLine
+        !(cleanTask.execution instanceof vscode.ProcessExecution)
       ) {
         return;
       }
 
       let relativeModeDir = modeDir.replace(workspaceFolder, '');
       relativeModeDir = replaceBackslashes(relativeModeDir);
-      cleanTask.execution.commandLine = `echo Cleaning ${relativeModeDir}...`;
+
+      if (cleanTask.execution.args.length !== 3) return;
+
+      cleanTask.execution.args[2] = `echo Cleaning ${relativeModeDir}...`;
 
       if (!pathExists(modeDir)) return;
 
@@ -710,35 +712,6 @@ function initDebugSingleFile() {
 }
 
 async function buildTaskCallback(singleFileBuild: boolean) {
-  if (!taskProvider || !taskProvider.tasks) {
-    const infoMessage = `buildCallback failed`;
-    logger.log(loggingActive, infoMessage);
-    return;
-  }
-
-  taskProvider.getTasks();
-
-  const projectFolder = taskProvider.getProjectFolder();
-  if (!projectFolder) return;
-
-  const buildTaskIndex = 0;
-  const buildTask = taskProvider.tasks[buildTaskIndex];
-
-  if (!buildTask) return;
-
-  if (
-    !buildTask.execution ||
-    !(buildTask.execution instanceof vscode.ShellExecution) ||
-    !buildTask.execution.commandLine
-  ) {
-    return;
-  }
-
-  buildTask.execution.commandLine = buildTask.execution.commandLine.replace(
-    'FILE_DIR',
-    projectFolder,
-  );
-
   if (!activeFolder) return;
 
   const buildDir = path.join(activeFolder, 'build');
@@ -749,7 +722,6 @@ async function buildTaskCallback(singleFileBuild: boolean) {
   if (!settingsProvider) return;
 
   await executeBuildTask(
-    buildTask,
     settingsProvider,
     activeFolder,
     buildMode,
@@ -758,35 +730,6 @@ async function buildTaskCallback(singleFileBuild: boolean) {
 }
 
 async function runTaskCallback() {
-  if (!taskProvider || !taskProvider.tasks) {
-    const infoMessage = `runCallback failed`;
-    logger.log(loggingActive, infoMessage);
-    return;
-  }
-
-  taskProvider.getTasks();
-
-  const projectFolder = taskProvider.getProjectFolder();
-  if (!projectFolder) return;
-
-  const runTaskIndex = 1;
-  const runTask = taskProvider.tasks[runTaskIndex];
-
-  if (!runTask) return;
-
-  if (
-    !runTask.execution ||
-    !(runTask.execution instanceof vscode.ShellExecution) ||
-    !runTask.execution.commandLine
-  ) {
-    return;
-  }
-
-  runTask.execution.commandLine = runTask.execution.commandLine.replace(
-    'FILE_DIR',
-    projectFolder,
-  );
-
   if (!activeFolder) return;
 
   const buildDir = path.join(activeFolder, 'build');
@@ -799,7 +742,6 @@ async function runTaskCallback() {
   }
 
   await executeRunTask(
-    runTask,
     activeFolder,
     buildMode,
     argumentsString,
@@ -808,11 +750,5 @@ async function runTaskCallback() {
 }
 
 function debugTaskCallback() {
-  if (!activeFolder || !workspaceFolder) {
-    const infoMessage = `debugCallback failed`;
-    logger.log(loggingActive, infoMessage);
-    return;
-  }
-
-  if (taskProvider) runDebugger(activeFolder, workspaceFolder, buildMode);
+  runDebugger(activeFolder, workspaceFolder, buildMode);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,13 +19,7 @@ import { LaunchProvider } from './provider/launchProvider';
 import { PropertiesProvider } from './provider/propertiesProvider';
 import { SettingsProvider } from './provider/settingsProvider';
 import { TaskProvider } from './provider/taskProvider';
-import {
-	foldersInDir,
-	mkdirRecursive,
-	pathExists,
-	replaceBackslashes,
-	rmdirRecursive,
-} from './utils/fileUtils';
+import { foldersInDir, mkdirRecursive, pathExists } from './utils/fileUtils';
 import * as logger from './utils/logger';
 import { Builds } from './utils/types';
 import {
@@ -190,12 +184,7 @@ function initWorkspaceProvider() {
   }
 
   if (!taskProvider) {
-    taskProvider = new TaskProvider(
-      settingsProvider,
-      workspaceFolder,
-      activeFolder,
-      buildMode,
-    );
+    taskProvider = new TaskProvider(workspaceFolder, activeFolder, buildMode);
   }
 }
 

--- a/src/provider/taskProvider.ts
+++ b/src/provider/taskProvider.ts
@@ -58,54 +58,6 @@ export class TaskProvider implements vscode.TaskProvider {
   }
 
   private setTasksDefinition() {
-    const taskType = 'shell';
-    const configJson: JsonTask = readJsonFile(this._tasksFile);
-
-    if (!configJson) {
-      return [];
-    }
-
-    this.tasks = [];
-
-    for (const taskJson of configJson.tasks) {
-      if (taskJson.type !== taskType) {
-        continue;
-      }
-
-      // const shellCommand = `${taskJson.command} ${taskJson.args.join(' ')}`;
-
-      const definition = {
-        type: taskType,
-        task: taskJson.label,
-      };
-      const scope = vscode.TaskScope.Workspace;
-      // let execution: vscode.ProcessExecution;
-
-      // if (this._settingsProvider.operatingSystem === OperatingSystems.windows) {
-      //   const shellOptions: vscode.ProcessExecutionOptions = {
-      //     executable: 'C:/Windows/System32/cmd.exe',
-      //     shellArgs: ['/d', '/c'],
-      //   };
-      //   execution = new vscode.ProcessExecution(shellCommand, shellOptions);
-      // } else {
-      //   execution = new vscode.ProcessExecution(shellCommand);
-      // }
-
-      const execution = new vscode.ProcessExecution(
-        'C:/Windows/System32/cmd.exe',
-        ['/d', '/c', 'COMMAND'],
-      );
-
-      const task = new vscode.Task(
-        definition,
-        scope,
-        taskJson.label,
-        EXTENSION_NAME,
-        execution,
-      );
-      this.tasks.push(task);
-    }
-
     this.addDebugTask();
 
     return this.tasks;

--- a/src/provider/taskProvider.ts
+++ b/src/provider/taskProvider.ts
@@ -72,24 +72,29 @@ export class TaskProvider implements vscode.TaskProvider {
         continue;
       }
 
-      const shellCommand = `${taskJson.command} ${taskJson.args.join(' ')}`;
+      // const shellCommand = `${taskJson.command} ${taskJson.args.join(' ')}`;
 
       const definition = {
         type: taskType,
         task: taskJson.label,
       };
       const scope = vscode.TaskScope.Workspace;
-      let execution: vscode.ShellExecution;
+      // let execution: vscode.ProcessExecution;
 
-      if (this._settingsProvider.operatingSystem === OperatingSystems.windows) {
-        const shellOptions: vscode.ShellExecutionOptions = {
-          executable: 'C:/Windows/System32/cmd.exe',
-          shellArgs: ['/d', '/c'],
-        };
-        execution = new vscode.ShellExecution(shellCommand, shellOptions);
-      } else {
-        execution = new vscode.ShellExecution(shellCommand);
-      }
+      // if (this._settingsProvider.operatingSystem === OperatingSystems.windows) {
+      //   const shellOptions: vscode.ProcessExecutionOptions = {
+      //     executable: 'C:/Windows/System32/cmd.exe',
+      //     shellArgs: ['/d', '/c'],
+      //   };
+      //   execution = new vscode.ProcessExecution(shellCommand, shellOptions);
+      // } else {
+      //   execution = new vscode.ProcessExecution(shellCommand);
+      // }
+
+      const execution = new vscode.ProcessExecution(
+        'C:/Windows/System32/cmd.exe',
+        ['/d', '/c', 'COMMAND'],
+      );
 
       const task = new vscode.Task(
         definition,

--- a/src/provider/taskProvider.ts
+++ b/src/provider/taskProvider.ts
@@ -22,7 +22,7 @@ const CONFIG_NAME = 'C/C++ Runner: Debug Session';
 
 export class TaskProvider implements vscode.TaskProvider {
   private readonly _tasksFile: string;
-  public tasks: Task[] | undefined;
+  public tasks: vscode.Task[] | undefined;
 
   constructor(
     private readonly _settingsProvider: SettingsProvider,
@@ -71,11 +71,6 @@ export class TaskProvider implements vscode.TaskProvider {
       if (taskJson.type !== taskType) {
         continue;
       }
-      if (taskJson.options) {
-        if (taskJson.options.hide) {
-          continue;
-        }
-      }
 
       const shellCommand = `${taskJson.command} ${taskJson.args.join(' ')}`;
 
@@ -83,7 +78,6 @@ export class TaskProvider implements vscode.TaskProvider {
         type: taskType,
         task: taskJson.label,
       };
-      const problemMatcher = '$gcc';
       const scope = vscode.TaskScope.Workspace;
       let execution: vscode.ShellExecution;
 
@@ -97,13 +91,12 @@ export class TaskProvider implements vscode.TaskProvider {
         execution = new vscode.ShellExecution(shellCommand);
       }
 
-      const task = new Task(
+      const task = new vscode.Task(
         definition,
         scope,
         taskJson.label,
         EXTENSION_NAME,
         execution,
-        problemMatcher,
       );
       this.tasks.push(task);
     }

--- a/src/provider/taskProvider.ts
+++ b/src/provider/taskProvider.ts
@@ -1,41 +1,25 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { extensionPath } from '../extension';
 import {
 	readJsonFile,
 	replaceBackslashes,
 	writeJsonFile,
 } from '../utils/fileUtils';
-import {
-	Builds,
-	JsonConfiguration,
-	JsonTask,
-	OperatingSystems,
-	Task,
-} from '../utils/types';
+import { Builds, JsonConfiguration, Task } from '../utils/types';
 import { getLaunchConfigIndex } from '../utils/vscodeUtils';
-import { SettingsProvider } from './settingsProvider';
 
 const EXTENSION_NAME = 'C_Cpp_Runner';
 const CONFIG_NAME = 'C/C++ Runner: Debug Session';
 
 export class TaskProvider implements vscode.TaskProvider {
-  private readonly _tasksFile: string;
   public tasks: vscode.Task[] | undefined;
 
   constructor(
-    private readonly _settingsProvider: SettingsProvider,
     private _workspaceFolder: string | undefined,
     private _activeFolder: string | undefined,
     private _buildMode: Builds,
   ) {
-    const templateDirectory = path.join(
-      extensionPath ? extensionPath : '',
-      'templates',
-    );
-    this._tasksFile = path.join(templateDirectory, 'tasks_template.json');
-
     this.getTasks();
   }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -21,7 +21,7 @@ export interface JsonTask {
 }
 
 export class Task extends vscode.Task {
-  override execution?: vscode.ShellExecution;
+  override execution?: vscode.ProcessExecution;
 }
 
 export class Commands {

--- a/src/utils/vscodeUtils.ts
+++ b/src/utils/vscodeUtils.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 
 import { extensionState } from '../extension';
 import { filesInDir, pathExists, readJsonFile } from './fileUtils';
-import { JsonConfiguration, JsonSettings } from './types';
+import { JsonConfiguration, JsonSettings, OperatingSystems } from './types';
 
 const STATUS_BAR_ALIGN = vscode.StatusBarAlignment.Left;
 const STATUS_BAR_PRIORITY = 50;
@@ -121,4 +121,35 @@ export function isCmakeProject() {
   }
 
   return cmakeFileFound;
+}
+
+export function getProcessExection(
+  operatingSystem: OperatingSystems,
+  commandLine: string,
+  activeFolder: string,
+) {
+  const options = {
+    cwd: activeFolder,
+  };
+
+  let execution: vscode.ProcessExecution | undefined;
+  if (operatingSystem === OperatingSystems.windows) {
+    execution = new vscode.ProcessExecution(
+      'C:/Windows/System32/cmd.exe',
+      ['/d', '/c', commandLine],
+      options,
+    );
+  } else {
+    let standard_shell = process.env['SHELL'];
+    if (!standard_shell) {
+      standard_shell = '/bin/bash';
+    }
+    execution = new vscode.ProcessExecution(
+      standard_shell,
+      ['-c', commandLine],
+      options,
+    );
+  }
+
+  return execution;
 }

--- a/src/utils/vscodeUtils.ts
+++ b/src/utils/vscodeUtils.ts
@@ -123,7 +123,7 @@ export function isCmakeProject() {
   return cmakeFileFound;
 }
 
-export function getProcessExection(
+export function getProcessExecution(
   operatingSystem: OperatingSystems,
   commandLine: string,
   activeFolder: string,


### PR DESCRIPTION
## Version 3.2.0: March 5, 2022

- **Info**: Now using relative paths for building the binary, hence the console output is shortened and more readable
- **Bugfix**: Hot fix since extension was not working anymore with VSCode 1.65.0