### PR TITLE
Update launch_template.json to use lldb to instead of cppdbg

### DIFF
--- a/templates/launch_template.json
+++ b/templates/launch_template.json
@@ -3,7 +3,7 @@
   "configurations": [
     {
       "name": "C/C++ Runner: Debug Session",
-      "type": "cppdbg",
+      "type": "lldb",
       "request": "launch",
       "args": [],
       "stopAtEntry": false,


### PR DESCRIPTION
I needed to add this to get this extension to work for debugging on Linux. Since LLDB is a required dep it made sense to me to file a PR.