### PR TITLE
excluded settings.json from blob pattern

### DIFF
--- a/src/provider/callbackProvider.ts
+++ b/src/provider/callbackProvider.ts
@@ -26,6 +26,11 @@ export abstract class CallbackProvider {
       '.vscode/**',
     );
 
+    const excludeSettingsFilePattern = new vscode.RelativePattern(
+      this._workspaceFolder,
+      '.vscode/{launch.json,c_cpp_properties.json}',
+    );
+
     this._fileWatcherOnDelete = vscode.workspace.createFileSystemWatcher(
       filePattern,
       true,
@@ -34,7 +39,7 @@ export abstract class CallbackProvider {
     );
 
     this._fileWatcherOnChange = vscode.workspace.createFileSystemWatcher(
-      filePattern,
+      excludeSettingsFilePattern,
       true,
       false,
       true,


### PR DESCRIPTION
should fix #152 
this excludes settings.json from didChange watcher, possibly removing some functionality that I'm unaware of. This also hardcodes the values of the pattern and it's probably shouldn't be done like this, I'm not too familiar with js/ts or vscode extensions so help would be appreciated